### PR TITLE
Allow skipping of IDTokenValidation if version is mc_v1.1

### DIFF
--- a/mobile-connect-demos/GSMA.MobileConnect.Demo.Universal/MainPage.xaml.cs
+++ b/mobile-connect-demos/GSMA.MobileConnect.Demo.Universal/MainPage.xaml.cs
@@ -15,8 +15,8 @@ namespace GSMA.MobileConnect.Demo.Universal
     /// </summary>
     public sealed partial class MainPage : Page
     {
-        private MobileConnectInterface _mobileConnect;
-        private MobileConnectConfig _config;
+        private readonly MobileConnectInterface _mobileConnect;
+        private readonly MobileConnectConfig _config;
         private string _state;
         private string _nonce;
         private Discovery.DiscoveryResponse _discoveryResponse;
@@ -88,6 +88,8 @@ namespace GSMA.MobileConnect.Demo.Universal
                 Scope = GetScope(),
                 Context = "demo",
                 BindingMessage = "demo auth",
+                // Accept valid results and results indicating validation was skipped due to missing support on the provider
+                AcceptedValidationResults = TokenValidationResult.Valid | TokenValidationResult.IdTokenValidationSkipped,
             };
 
             var newResponse = _mobileConnect.StartAuthentication(_discoveryResponse,
@@ -111,7 +113,7 @@ namespace GSMA.MobileConnect.Demo.Universal
             accessToken.Text = _token.AccessToken;
             idToken.Text = _token.IdToken;
             timeReceived.Text = _token.TimeReceived.ToString("u");
-            applicationName.Text = _discoveryResponse.ApplicationShortName;
+            applicationName.Text = _discoveryResponse.ApplicationShortName ?? "";
             validationResult.Text = response.TokenResponse.ValidationResult.ToString();
 
             loginPanel.Visibility = Visibility.Collapsed;

--- a/mobile-connect-demos/GSMA.MobileConnect.Demo.Web/Controllers/MobileConnectController.cs
+++ b/mobile-connect-demos/GSMA.MobileConnect.Demo.Web/Controllers/MobileConnectController.cs
@@ -10,7 +10,7 @@ namespace GSMA.MobileConnect.Demo.Web.Controllers
     [RoutePrefix("api/mobileconnect")]
     public class MobileConnectController : ApiController
     {
-        private MobileConnectWebInterface _mobileConnect;
+        private readonly MobileConnectWebInterface _mobileConnect;
 
         public MobileConnectController(MobileConnectWebInterface mobileConnect)
         {
@@ -92,7 +92,9 @@ namespace GSMA.MobileConnect.Demo.Web.Controllers
         [Route("")]
         public async Task<IHttpActionResult> HandleRedirect(string sdksession=null, string mcc_mnc=null, string code=null, string expectedState=null, string expectedNonce=null)
         {
-            var response = await _mobileConnect.HandleUrlRedirectAsync(Request, Request.RequestUri, sdksession, expectedState, expectedNonce, new MobileConnectRequestOptions());
+            // Accept valid results and results indicating validation was skipped due to missing support on the provider
+            var requestOptions = new MobileConnectRequestOptions { AcceptedValidationResults = Authentication.TokenValidationResult.Valid | Authentication.TokenValidationResult.IdTokenValidationSkipped };
+            var response = await _mobileConnect.HandleUrlRedirectAsync(Request, Request.RequestUri, sdksession, expectedState, expectedNonce, requestOptions);
             
             return CreateResponse(response);
         }

--- a/mobile-connect-sdk/GSMA.MobileConnect.Test/Authentication/AuthenticationServiceTests.cs
+++ b/mobile-connect-sdk/GSMA.MobileConnect.Test/Authentication/AuthenticationServiceTests.cs
@@ -295,7 +295,7 @@ namespace GSMA.MobileConnect.Test.Authentication
             string issuer = "http://mobileconnect.io";
             int? maxAge = 36000;
 
-            var actual = _authentication.ValidateTokenResponse(tokenResponse, clientId, issuer, nonce, maxAge, jwks);
+            var actual = _authentication.ValidateTokenResponse(tokenResponse, clientId, issuer, nonce, maxAge, jwks, "mc_v1.2");
 
             Assert.AreEqual(TokenValidationResult.Valid, actual);
         }
@@ -312,7 +312,7 @@ namespace GSMA.MobileConnect.Test.Authentication
             string issuer = "http://mobileconnect.io";
             int? maxAge = 36000;
 
-            var actual = _authentication.ValidateTokenResponse(tokenResponse, clientId, issuer, nonce, maxAge, jwks);
+            var actual = _authentication.ValidateTokenResponse(tokenResponse, clientId, issuer, nonce, maxAge, jwks, "mc_v1.2");
 
             Assert.AreEqual(TokenValidationResult.IncompleteTokenResponse, actual);
         }
@@ -329,7 +329,7 @@ namespace GSMA.MobileConnect.Test.Authentication
             string issuer = "http://mobileconnect.io";
             int? maxAge = 36000;
 
-            var actual = _authentication.ValidateTokenResponse(tokenResponse, clientId, issuer, nonce, maxAge, jwks);
+            var actual = _authentication.ValidateTokenResponse(tokenResponse, clientId, issuer, nonce, maxAge, jwks, "mc_v1.2");
 
             Assert.AreEqual(TokenValidationResult.AccessTokenMissing, actual);
         }
@@ -345,7 +345,7 @@ namespace GSMA.MobileConnect.Test.Authentication
             string clientId = "x-clientid-x";
             int? maxAge = 36000;
 
-            var actual = _authentication.ValidateTokenResponse(tokenResponse, clientId, "notissuer", nonce, maxAge, jwks);
+            var actual = _authentication.ValidateTokenResponse(tokenResponse, clientId, "notissuer", nonce, maxAge, jwks, "mc_v1.2");
 
             Assert.AreEqual(TokenValidationResult.InvalidIssuer, actual);
         }

--- a/mobile-connect-sdk/GSMA.MobileConnect.Test/Authentication/TokenValidationTests.cs
+++ b/mobile-connect-sdk/GSMA.MobileConnect.Test/Authentication/TokenValidationTests.cs
@@ -10,6 +10,8 @@ namespace GSMA.MobileConnect.Test.Authentication
         private string clientId = "x-clientid-x";
         private string issuer = "http://mobileconnect.io";
         private int? maxAge = 36000;
+        private string _allValidationSupportedVersion = "mc_v1.2";
+        private string _validationUnsupportedVersion = "mc_v1.1";
 
         [Test]
         public void ValidateIdTokenShouldValidateWhenAllValid()
@@ -18,7 +20,7 @@ namespace GSMA.MobileConnect.Test.Authentication
             var idToken = "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJub25jZSI6IjEyMzQ1Njc4OTAiLCJhdWQiOiJ4LWNsaWVudGlkLXgiLCJhenAiOiJ4LWNsaWVudGlkLXgiLCJpc3MiOiJodHRwOi8vbW9iaWxlY29ubmVjdC5pbyIsImV4cCI6MjE0NzQ4MzY0NywiYXV0aF90aW1lIjoyMTQ3NDgzNjQ3LCJpYXQiOjE0NzEwMDczMjd9.U9c5iuybG4GIvrbQH5BT9AgllRbPL6SuIzL4Y3MW7VlCVIQOc_HFfkiLa0LNvqZiP-kFlADmnkzuuQxPq7IyaOILVYct20mrcOb_U_zMli4jg-t9P3BxHaq3ds9JlLBjz0oewd01ZQtWHgRnrGymfKAIojzHlde-aePuL1M26Eld5zoKQvCLcKAynZsjKsWF_6YdLk-uhlC5ofMOaOoPirPSPAxYvbj91z3o9XIgSHoU-umN7AJ6UQ4H-ulfftlRGK8hz0Yzpf2MHOy9OHg1u3ayfCaaf8g5zKGngcz0LgK9VAw2B31xJw-RHkPPh0Hz82FgBc4588oEFC1c22GGTw";
             var jwks = JsonConvert.DeserializeObject<JWKeyset>(jwksJson);
 
-            TokenValidationResult actual = TokenValidation.ValidateIdToken(idToken, clientId, issuer, nonce, maxAge, jwks);
+            TokenValidationResult actual = TokenValidation.ValidateIdToken(idToken, clientId, issuer, nonce, maxAge, jwks, _allValidationSupportedVersion);
 
             Assert.AreEqual(TokenValidationResult.Valid, actual);
         }
@@ -30,7 +32,7 @@ namespace GSMA.MobileConnect.Test.Authentication
             var idToken = "";
             var jwks = JsonConvert.DeserializeObject<JWKeyset>(jwksJson);
 
-            TokenValidationResult actual = TokenValidation.ValidateIdToken(idToken, clientId, issuer, nonce, maxAge, jwks);
+            TokenValidationResult actual = TokenValidation.ValidateIdToken(idToken, clientId, issuer, nonce, maxAge, jwks, _allValidationSupportedVersion);
 
             Assert.AreEqual(TokenValidationResult.IdTokenMissing, actual);
         }
@@ -42,9 +44,45 @@ namespace GSMA.MobileConnect.Test.Authentication
             var idToken = "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJub25jZSI6IjEyMzQ1Njc4OTAiLCJhdWQiOiJ4LWNsaWVudGlkLXkiLCJhenAiOiJ4LWNsaWVudGlkLXkiLCJpc3MiOiJodHRwOi8vbW9iaWxlY29ubmVjdC5pbyIsImV4cCI6MjE0NzQ4MzY0NywiYXV0aF90aW1lIjoyMTQ3NDgzNjQ3LCJpYXQiOjE0NzEwMDc2NzR9.byu8aDef11sJPpPD9WM_j5uv92CsQEJLJ23SVCwrmf-btdyViTe5q1Q0X1hjVzv6FcCQLlrdJj1ib4sky6It1kVEEDk_E7w8KHH1CmmApghWh2lozJRlg8LQTQXgvfnUPeSLsoGBDYWI502aUhyy9V_zm9M0F3Vi0GWmDVZeXIvUlqdGd1YdzO0cmEfc9nyQSchimVmc-0etCGJn8qehvCZa_x96_u-qJeUiOb_7NypECoVDv8UzAZ48P5Dq-iDCYP6jCmOjdZ36b4JO6co1OnYp4cGONqZTQadVDewAfskKtGkspm6XUdil0WDct1DMuPnDuH1eweQtYopxtHRsjw";
             var jwks = JsonConvert.DeserializeObject<JWKeyset>(jwksJson);
 
-            TokenValidationResult actual = TokenValidation.ValidateIdToken(idToken, clientId, issuer, nonce, maxAge, jwks);
+            TokenValidationResult actual = TokenValidation.ValidateIdToken(idToken, clientId, issuer, nonce, maxAge, jwks, _allValidationSupportedVersion);
 
             Assert.AreEqual(TokenValidationResult.InvalidAudAndAzp, actual);
+        }
+
+        [Test]
+        public void ValidateIdTokenShouldReturnSkippedWhenUnsupportedVersionAndClaimsValidationFailed()
+        {
+            var jwksJson = "{\"keys\":[{\"alg\":\"RS256\",\"e\":\"AQAB\",\"n\":\"hzr2li5ABVbbQ4BvdDskl6hejaVw0tIDYO-C0GBr5lRA-AXtmCO7bh0CEC9-R6mqctkzUhVnU22Vrj-B1J0JtJoaya9VTC3DdhzI_-7kxtIc5vrHq-ss5wo8-tK7UqtKLSRf9DcyZA0H9FEABbO5Qfvh-cfK4EI_ytA5UBZgO322RVYgQ9Do0D_-jf90dcuUgoxz_JTAOpVNc0u_m9LxGnGL3GhMbxLaX3eUublD40aK0nS2k37dOYOpQHxuAS8BZxLvS6900qqaZ6z0kwZ2WFq-hhk3Imd6fweS724fzqVslY7rHpM5n7z5m7s1ArurU1dBC1Dxw1Hzn6ZeJkEaZQ\",\"kty\":\"RSA\",\"use\":\"sig\"}]}";
+            var idToken = "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJub25jZSI6IjEyMzQ1Njc4OTAiLCJhdWQiOiJ4LWNsaWVudGlkLXgiLCJhenAiOiJ4LWNsaWVudGlkLXgiLCJpc3MiOiJodHRwOi8vbW9iaWxlY29ubmVjdC5pbyIsImV4cCI6MjE0NzQ4MzY0NywiYXV0aF90aW1lIjoyMTQ3NDgzNjQ3LCJpYXQiOjE0NzEwMDczMjd9.U9c5iuybG4GIvrbQH5BT9AgllRbPL6SuIzL4Y3MW7VlCVIQOc_HFfkiLa0LNvqZiP-kFlADmnkzuuQxPq7IyaOILVYct20mrcOb_U_zMli4jg-t9P3BxHaq3ds9JlLBjz0oewd01ZQtWHgRnrGymfKAIojzHlde-aePuL1M26Eld5zoKQvCLcKAynZsjKsWF_6YdLk-uhlC5ofMOaOoPirPSPAxYvbj91z3o9XIgSHoU-umN7AJ6UQ4H-ulfftlRGK8hz0Yzpf2MHOy9OHg1u3ayfCaaf8g5zKGngcz0LgK9VAw2B31xJw-RHkPPh0Hz82FgBc4588oEFC1c22GGTw";
+            var jwks = JsonConvert.DeserializeObject<JWKeyset>(jwksJson);
+
+            TokenValidationResult actual = TokenValidation.ValidateIdToken(idToken, clientId, null, nonce, maxAge, jwks, _validationUnsupportedVersion);
+
+            Assert.AreEqual(TokenValidationResult.IdTokenValidationSkipped, actual);
+        }
+
+        [Test]
+        public void ValidateIdTokenShouldReturnSkippedWhenUnsupportedVersionAndSignatureValidationFailed()
+        {
+            var jwksJson = "{\"keys\":[{\"alg\":\"RS256\",\"e\":\"AQAB\",\"n\":\"hzr2li5ABVbbQ4BvdDskl6hejaVw0tIDYO-C0GBr5lRA-AXtmCO7bh0CEC9-R6mqctkzUhVnU22Vrj-B1J0JtJoaya9VTC3DdhzI_-7kxtIc5vrHq-ss5wo8-tK7UqtKLSRf9DcyZA0H9FEABbO5Qfvh-cfK4EI_ytA5UBZgO322RVYgQ9Do0D_-jf90dcuUgoxz_JTAOpVNc0u_m9LxGnGL3GhMbxLaX3eUublD40aK0nS2k37dOYOpQHxuAS8BZxLvS6900qqaZ6z0kwZ2WFq-hhk3Imd6fweS724fzqVslY7rHpM5n7z5m7s1ArurU1dBC1Dxw1Hzn6ZeJkEaZQ\",\"kty\":\"RSA\",\"use\":\"sig\"}]}";
+            var idToken = "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJub25jZSI6IjEyMzQ1Njc4OTAiLCJhdWQiOiJ4LWNsaWVudGlkLXgiLCJhenAiOiJ4LWNsaWVudGlkLXgiLCJpc3MiOiJodHRwOi8vbW9iaWxlY29ubmVjdC5pbyIsImV4cCI6MjE0NzQ4MzY0NywiYXV0aF90aW1lIjoyMTQ3NDgzNjQ3LCJpYXQiOjE0NzEwMDczMjd9.U9c5iuybG4GIvrbQH5BT9AgllRbPL6SuIzL4Y3MW7VlCVIQOc_HFfkiLa0LNvqZiP-kFlADmnkzuuQxPq7IyaOILVYct20mrcOb_U_zMli4jg-t9P3BxHaq3ds9JlLBjz0oewd01ZQtWHgRnrGymfKAIojzHlde-aePuL1M26Eld5zoKQvCLcKAynZsjKsWF_6YdLk-uhlC5ofMOaOoPirPSPAxYvbj91z3o9XIgSHoU-umN7AJ6UQ4H-ulfftlRGK8hz0Yzpf2MHOy9OHg1X3ayfCaaf8g5zKGngcz0LgK9VAw2B31xJw-RHkPPh0Hz82FgBc4588oEFC1c22GGTw";
+            var jwks = JsonConvert.DeserializeObject<JWKeyset>(jwksJson);
+
+            TokenValidationResult actual = TokenValidation.ValidateIdToken(idToken, clientId, issuer, nonce, maxAge, jwks, _validationUnsupportedVersion);
+
+            Assert.AreEqual(TokenValidationResult.IdTokenValidationSkipped, actual);
+        }
+
+        [Test]
+        public void ValidateIdTokenShouldReturnValidWhenUnsupportedVersionAndValidationPassed()
+        {
+            var jwksJson = "{\"keys\":[{\"alg\":\"RS256\",\"e\":\"AQAB\",\"n\":\"hzr2li5ABVbbQ4BvdDskl6hejaVw0tIDYO-C0GBr5lRA-AXtmCO7bh0CEC9-R6mqctkzUhVnU22Vrj-B1J0JtJoaya9VTC3DdhzI_-7kxtIc5vrHq-ss5wo8-tK7UqtKLSRf9DcyZA0H9FEABbO5Qfvh-cfK4EI_ytA5UBZgO322RVYgQ9Do0D_-jf90dcuUgoxz_JTAOpVNc0u_m9LxGnGL3GhMbxLaX3eUublD40aK0nS2k37dOYOpQHxuAS8BZxLvS6900qqaZ6z0kwZ2WFq-hhk3Imd6fweS724fzqVslY7rHpM5n7z5m7s1ArurU1dBC1Dxw1Hzn6ZeJkEaZQ\",\"kty\":\"RSA\",\"use\":\"sig\"}]}";
+            var idToken = "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJub25jZSI6IjEyMzQ1Njc4OTAiLCJhdWQiOiJ4LWNsaWVudGlkLXgiLCJhenAiOiJ4LWNsaWVudGlkLXgiLCJpc3MiOiJodHRwOi8vbW9iaWxlY29ubmVjdC5pbyIsImV4cCI6MjE0NzQ4MzY0NywiYXV0aF90aW1lIjoyMTQ3NDgzNjQ3LCJpYXQiOjE0NzEwMDczMjd9.U9c5iuybG4GIvrbQH5BT9AgllRbPL6SuIzL4Y3MW7VlCVIQOc_HFfkiLa0LNvqZiP-kFlADmnkzuuQxPq7IyaOILVYct20mrcOb_U_zMli4jg-t9P3BxHaq3ds9JlLBjz0oewd01ZQtWHgRnrGymfKAIojzHlde-aePuL1M26Eld5zoKQvCLcKAynZsjKsWF_6YdLk-uhlC5ofMOaOoPirPSPAxYvbj91z3o9XIgSHoU-umN7AJ6UQ4H-ulfftlRGK8hz0Yzpf2MHOy9OHg1u3ayfCaaf8g5zKGngcz0LgK9VAw2B31xJw-RHkPPh0Hz82FgBc4588oEFC1c22GGTw";
+            var jwks = JsonConvert.DeserializeObject<JWKeyset>(jwksJson);
+
+            TokenValidationResult actual = TokenValidation.ValidateIdToken(idToken, clientId, issuer, nonce, maxAge, jwks, _validationUnsupportedVersion);
+
+            Assert.AreEqual(TokenValidationResult.IdTokenValidationSkipped, actual);
         }
 
         [Test]

--- a/mobile-connect-sdk/GSMA.MobileConnect/Authentication/AuthenticationService.cs
+++ b/mobile-connect-sdk/GSMA.MobileConnect/Authentication/AuthenticationService.cs
@@ -258,7 +258,7 @@ namespace GSMA.MobileConnect.Authentication
         }
 
         /// <inheritdoc/>
-        public TokenValidationResult ValidateTokenResponse(RequestTokenResponse tokenResponse, string clientId, string issuer, string nonce, int? maxAge, JWKeyset keyset)
+        public TokenValidationResult ValidateTokenResponse(RequestTokenResponse tokenResponse, string clientId, string issuer, string nonce, int? maxAge, JWKeyset keyset, string version)
         {
             if (tokenResponse?.ResponseData == null)
             {
@@ -273,7 +273,7 @@ namespace GSMA.MobileConnect.Authentication
                 return result;
             }
 
-            result = TokenValidation.ValidateIdToken(tokenResponse.ResponseData.IdToken, clientId, issuer, nonce, maxAge, keyset);
+            result = TokenValidation.ValidateIdToken(tokenResponse.ResponseData.IdToken, clientId, issuer, nonce, maxAge, keyset, version);
             if (result != TokenValidationResult.Valid)
             {
                 Log.Warning(() => $"IDToken was invalid from issuer={issuer} for reason={result}");

--- a/mobile-connect-sdk/GSMA.MobileConnect/Authentication/IAuthenticationService.cs
+++ b/mobile-connect-sdk/GSMA.MobileConnect/Authentication/IAuthenticationService.cs
@@ -121,7 +121,8 @@ namespace GSMA.MobileConnect.Authentication
         /// <param name="nonce">Nonce value required for validating Id token claims</param>
         /// <param name="maxAge">MaxAge value required for validating Id token claims</param>
         /// <param name="keyset">Keyset required for validating Id token signature</param>
+        /// <param name="version">Max version of mobile connect services supported by current provider, used to skip some unsupported validation steps</param>
         /// <returns>TokenValidationResult indicating the token response is valid or why the token response is invalid</returns>
-        TokenValidationResult ValidateTokenResponse(RequestTokenResponse tokenResponse, string clientId, string issuer, string nonce, int? maxAge, JWKeyset keyset);
+        TokenValidationResult ValidateTokenResponse(RequestTokenResponse tokenResponse, string clientId, string issuer, string nonce, int? maxAge, JWKeyset keyset, string version);
     }
 }

--- a/mobile-connect-sdk/GSMA.MobileConnect/Authentication/JWKeysetService.cs
+++ b/mobile-connect-sdk/GSMA.MobileConnect/Authentication/JWKeysetService.cs
@@ -34,6 +34,11 @@ namespace GSMA.MobileConnect.Authentication
         /// <inheritdoc/>
         public async Task<JWKeyset> RetrieveJWKSAsync(string url)
         {
+            if(string.IsNullOrEmpty(url))
+            {
+                return null;
+            }
+
             var cached = await RetrieveFromCache(url);
 
             if (cached != null && !cached.HasExpired)

--- a/mobile-connect-sdk/GSMA.MobileConnect/Authentication/TokenValidationResult.cs
+++ b/mobile-connect-sdk/GSMA.MobileConnect/Authentication/TokenValidationResult.cs
@@ -84,5 +84,10 @@ namespace GSMA.MobileConnect.Authentication
         /// The token response is null or missing required data
         /// </summary>
         IncompleteTokenResponse = 65536,
+        /// <summary>
+        /// The token validation was skipped because the provider does not 
+        /// support full validation of the token. Allow this result if you will be making requests to providers that only support mc_v1.1
+        /// </summary>
+        IdTokenValidationSkipped = 131072,
     }
 }

--- a/mobile-connect-sdk/GSMA.MobileConnect/Discovery/SupportedVersions.cs
+++ b/mobile-connect-sdk/GSMA.MobileConnect/Discovery/SupportedVersions.cs
@@ -25,10 +25,18 @@ namespace GSMA.MobileConnect.Discovery
 
         private readonly Dictionary<string, string> _initialValuesDict;
         private readonly Version _maxSupportedVersion;
+        private readonly string _maxSupportedVersionString;
+
+        internal static string R1Version = "mc_v1.1";
 
         internal Dictionary<string, string> InitialValues
         {
             get { return _initialValuesDict; }
+        }
+
+        internal string MaxSupportedVersionString
+        {
+            get { return _maxSupportedVersionString; }
         }
 
         /// <summary>
@@ -38,23 +46,26 @@ namespace GSMA.MobileConnect.Discovery
         public SupportedVersions(Dictionary<string, string> versionSupport)
         {
             _initialValuesDict = versionSupport ?? new Dictionary<string, string>();
-            _maxSupportedVersion = IdentifyMaxSupportedVersion(_initialValuesDict);
+            _maxSupportedVersionString = CalculateMaxSupportedVersion(_initialValuesDict);
+            _maxSupportedVersion = GetAsVersion(_maxSupportedVersionString);
         }
 
-        private static Version IdentifyMaxSupportedVersion(Dictionary<string, string> versionSupport)
+        private static string CalculateMaxSupportedVersion(Dictionary<string, string> versionSupport)
         {
             // Use default scope as default max version
-            Version max = GetAsVersion(Utils.MobileConnectVersions.CoerceVersion(null, MobileConnectConstants.MOBILECONNECT));
+            string maxString = Utils.MobileConnectVersions.CoerceVersion(null, MobileConnectConstants.MOBILECONNECT);
+            Version max = GetAsVersion(maxString);
             foreach (var kvp in versionSupport)
             {
                 var version = GetAsVersion(kvp.Value);
                 if(version > max)
                 {
                     max = version;
+                    maxString = kvp.Value;
                 }
             }
 
-            return max;
+            return maxString;
         }
 
         private static Version GetAsVersion(string version)

--- a/mobile-connect-sdk/GSMA.MobileConnect/Log.cs
+++ b/mobile-connect-sdk/GSMA.MobileConnect/Log.cs
@@ -31,7 +31,7 @@ namespace GSMA.MobileConnect
         /// <param name="message">Message to log</param>
         public static void Info(string message)
         {
-            if (_log == null || _level < LogLevel.Info) return;
+            if (_log == null || _level > LogLevel.Info) return;
             _log.Info(message);
         }
 
@@ -41,7 +41,7 @@ namespace GSMA.MobileConnect
         /// <param name="messageFunc">Message generating function</param>
         public static void Info(Func<string> messageFunc)
         {
-            if (_log == null || messageFunc == null || _level < LogLevel.Info) return;
+            if (_log == null || messageFunc == null || _level > LogLevel.Info) return;
             _log.Info(messageFunc());
         }
 
@@ -51,7 +51,7 @@ namespace GSMA.MobileConnect
         /// <param name="message">Message to log</param>
         public static void Debug(string message)
         {
-            if (_log == null || _level < LogLevel.Debug) return;
+            if (_log == null || _level > LogLevel.Debug) return;
             _log.Debug(message);
         }
 
@@ -61,7 +61,7 @@ namespace GSMA.MobileConnect
         /// <param name="messageFunc">Message generating function</param>
         public static void Debug(Func<string> messageFunc)
         {
-            if (_log == null || messageFunc == null || _level < LogLevel.Debug) return;
+            if (_log == null || messageFunc == null || _level > LogLevel.Debug) return;
             _log.Debug(messageFunc());
         }
 
@@ -71,7 +71,7 @@ namespace GSMA.MobileConnect
         /// <param name="message">Message to log</param>
         public static void Warning(string message)
         {
-            if (_log == null || _level < LogLevel.Warning) return;
+            if (_log == null || _level > LogLevel.Warning) return;
             _log.Warning(message);
         }
 
@@ -81,7 +81,7 @@ namespace GSMA.MobileConnect
         /// <param name="messageFunc">Message generating function</param>
         public static void Warning(Func<string> messageFunc)
         {
-            if (_log == null || messageFunc == null || _level < LogLevel.Warning) return;
+            if (_log == null || messageFunc == null || _level > LogLevel.Warning) return;
             _log.Warning(messageFunc());
         }
 
@@ -92,7 +92,7 @@ namespace GSMA.MobileConnect
         /// <param name="ex">Exception to log</param>
         public static void Error(string message, Exception ex = null)
         {
-            if (_log == null || _level < LogLevel.Error) return;
+            if (_log == null || _level > LogLevel.Error) return;
             _log.Error(message, ex);
         }
 
@@ -103,7 +103,7 @@ namespace GSMA.MobileConnect
         /// <param name="ex">Exception to log</param>
         public static void Error(Func<string> messageFunc, Exception ex = null)
         {
-            if (_log == null || messageFunc == null || _level < LogLevel.Error) return;
+            if (_log == null || messageFunc == null || _level > LogLevel.Error) return;
             _log.Warning(messageFunc());
         }
 
@@ -114,7 +114,7 @@ namespace GSMA.MobileConnect
         /// <param name="ex">Exception to log</param>
         public static void Fatal(string message, Exception ex)
         {
-            if (_log == null || _level < LogLevel.Fatal) return;
+            if (_log == null || _level > LogLevel.Fatal) return;
             _log.Fatal(message, ex);
         }
 
@@ -125,7 +125,7 @@ namespace GSMA.MobileConnect
         /// <param name="ex">Exception to log</param>
         public static void Fatal(Func<string> messageFunc, Exception ex)
         {
-            if (_log == null || messageFunc == null || _level < LogLevel.Fatal) return;
+            if (_log == null || messageFunc == null || _level > LogLevel.Fatal) return;
             _log.Fatal(messageFunc(), ex);
         }
     }
@@ -135,10 +135,6 @@ namespace GSMA.MobileConnect
     /// </summary>
     public enum LogLevel
     {
-        /// <summary>
-        /// No log messages will be logged
-        /// </summary>
-        None = 0,
         /// <summary>
         /// Messages Info level and above will be logged
         /// </summary>
@@ -159,5 +155,9 @@ namespace GSMA.MobileConnect
         /// Messages fatal level and above will be logged
         /// </summary>
         Fatal = 5,
+        /// <summary>
+        /// No log messages will be logged
+        /// </summary>
+        None = 99,
     }
 }


### PR DESCRIPTION
- Fixed exception on null jwks url when calling against R1 sandbox
- Added TokenValidationResult.IdTokenValidationSkipped for use when calling R1 endpoint that doesn't support issuer and signature validation
- Returned new validation result if version is mc_v1.1 and actual validation result != valid